### PR TITLE
New Build: 2025.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,5 +43,5 @@ jobs:
           context: .
           platforms: linux/arm64,linux/amd64
           push: true
-          tags: keytelematics/docker-awscli:latest
+          tags: keytelematics/docker-awscli:2025.11
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
…lab runners as the docker api has changed between v1.43 and 1.44. This will build a new image and tag it as 2025.11 which i can test with. If that succeeds, i'll then tag it as latest