### PR TITLE
awscli v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,6 @@
 name: Publish Docker Image
 
-on:
-  push:
-    branches:
-      - master
+on: push
 
 jobs:
   push_to_registry:
@@ -42,6 +39,6 @@ jobs:
         with:
           context: .
           platforms: linux/arm64,linux/amd64
-          push: true
+          push: ${{ github.ref == 'refs/heads/master' }}
           tags: keytelematics/docker-awscli:2025.11
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,21 @@
 FROM docker:git
 
 RUN apk update
-RUN apk -Uuv add groff 
-RUN apk -Uuv add less 
-RUN apk -Uuv add python3 
-RUN apk -Uuv add py3-pip 
-RUN apk -Uuv add jq 
-RUN apk -Uuv add gettext 
-RUN apk -Uuv add bash 
-RUN apk -Uuv add awscli 
-# RUN pip3 install awscli 
-RUN apk --purge -v del py3-pip
+RUN apk add --no-cache \
+        curl \
+        unzip \
+        groff \
+        less \
+        jq \
+        gettext \
+        bash
+
+# Install AWS CLI v2
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" \
+    && unzip /tmp/awscliv2.zip -d /tmp \
+    && /tmp/aws/install \
+    && rm -rf /tmp/aws /tmp/awscliv2.zip
+    
 RUN rm /var/cache/apk/*
 
 CMD ["bash"]


### PR DESCRIPTION
Changed to install awscli v2 using AWS' recommended approach. This will publish as 2025.11 if succeeds, so wont replace latest yet